### PR TITLE
Derive more useful traits

### DIFF
--- a/src/mac.rs
+++ b/src/mac.rs
@@ -23,7 +23,7 @@ use hash32_derive::Hash32;
 ///
 /// [decode]: #method.decode
 /// [encode]: #method.encode
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Frame<'p> {
     /// Header
     pub header: Header,
@@ -211,7 +211,7 @@ pub enum WriteFooter {
 }
 
 /// MAC frame header
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Header {
     /// Frame Type
     pub frame_type: FrameType,
@@ -461,7 +461,7 @@ impl Header {
 /// Defines the type of a MAC frame
 ///
 /// Part of [`Header`].
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum FrameType {
     /// Beacon
     Beacon = 0b000,
@@ -505,7 +505,7 @@ impl FrameType {
 ///
 /// Part of [`Header`]. Auxiliary security headers are currently unsupported by
 /// this implementation.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Security {
     /// No auxiliary security header is present
     None = 0b0,
@@ -534,7 +534,7 @@ impl Security {
 }
 
 /// Defines version information for a frame
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum FrameVersion {
     /// A frame conforming to the 802.15.4-2003 standard
     Ieee802154_2003 = 0b00,
@@ -569,7 +569,7 @@ impl FrameVersion {
 }
 
 /// Defines the type of Address
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum AddressMode {
     /// PAN identifier and address field are not present
     None = 0b00,
@@ -900,7 +900,7 @@ impl Address {
 }
 
 /// Signals an error that occured while decoding bytes
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum DecodeError {
     /// Buffer does not contain enough bytes
     NotEnoughBytes,


### PR DESCRIPTION
Unfortunately I can't derive `Hash32` for all the types, as the `hash32`
crate doesn't support enums. See https://github.com/japaric/hash32/issues/3.