### PR TITLE
Refactor encode / decode functions to use `bytes::Buf` and `bytes::BufMut`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 <a name="v0.3.0"></a>
+
+### Unreleased
+#### Changed
+- `&mut [u8]` was changed to `&mut dyn BufMut` in `encode(..)` functions. This allow end-user have control of allocation.
+- `&[u8]` was changed whenever possible to `&mut dyn Buf`
+- `Address::None` was removed in favour of `Option<Address>`
+
 ### v0.3.0 (2019-04-20)
 
 - Derive more useful traits for the various types ([#20])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ travis-ci   = { repository = "braun-robotics/ieee802154" }
 hash32        = "0.1"
 hash32-derive = "0.1"
 bytes = { version = "0.5", default-features=false }
+
+[dev-dependencies]
+static-bytes = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,5 @@ travis-ci   = { repository = "braun-robotics/ieee802154" }
 byteorder     = { version = "1", default-features = false }
 hash32        = "0.1"
 hash32-derive = "0.1"
+bitflags = "1.2"
+bytes = { version = "0.5", default-features=false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ travis-ci   = { repository = "braun-robotics/ieee802154" }
 
 
 [dependencies]
-byteorder     = { version = "1", default-features = false }
 hash32        = "0.1"
 hash32-derive = "0.1"
 bitflags = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,4 @@ travis-ci   = { repository = "braun-robotics/ieee802154" }
 [dependencies]
 hash32        = "0.1"
 hash32-derive = "0.1"
-bitflags = "1.2"
 bytes = { version = "0.5", default-features=false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,4 +26,3 @@
 #[macro_use]
 mod utils;
 pub mod mac;
-

--- a/src/mac/beacon.rs
+++ b/src/mac/beacon.rs
@@ -143,7 +143,6 @@ impl SuperframeSpecification {
     /// # Panics
     ///
     /// Panics if the buffer is not long enough to hold the frame.
-    ///
     pub fn encode(&self, buf: &mut [u8]) -> usize {
         let bo = u8::from(self.beacon_order.clone());
         let so = u8::from(self.superframe_order.clone());
@@ -242,7 +241,6 @@ impl GuaranteedTimeSlotDescriptor {
     /// # Panics
     ///
     /// Panics if the buffer is not long enough to hold the frame.
-    ///
     pub fn encode(&self, buf: &mut [u8]) -> usize {
         let size = self.short_address.encode(&mut buf[..2]);
         buf[size] = self.starting_slot | self.length << 4;
@@ -347,7 +345,6 @@ impl GuaranteedTimeSlotInformation {
     /// # Panics
     ///
     /// Panics if the buffer is not long enough to hold the frame.
-    ///
     pub fn encode(&self, buf: &mut [u8]) -> usize {
         assert!(self.slot_count <= 7);
         let mut size = 1usize; // header byte
@@ -400,7 +397,6 @@ const EXTENDED_MASK: u8 = 0b0111_0000;
 /// +-------------+----------+----------------+----------+
 ///      0 - 2         3         4 - 6             7        bit
 /// ```
-///
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct PendingAddress {
     short_address_count: usize,
@@ -478,7 +474,6 @@ impl PendingAddress {
     /// # Panics
     ///
     /// Panics if the buffer is not long enough to hold the frame.
-    ///
     pub fn encode(&self, buf: &mut [u8]) -> usize {
         assert!(self.short_address_count <= 7);
         assert!(self.extended_address_count <= 7);
@@ -561,7 +556,6 @@ impl Beacon {
     /// # Panics
     ///
     /// Panics if the buffer is not long enough to hold the frame.
-    ///
     pub fn encode(&self, buf: &mut [u8]) -> usize {
         let size = self.superframe_spec.encode(buf);
         let mut offset = size;

--- a/src/mac/beacon.rs
+++ b/src/mac/beacon.rs
@@ -286,7 +286,6 @@ impl GuaranteedTimeSlotInformation {
             length: 0,
             direction: Direction::Receive,
         }; 7];
-        let mut offset = 1;
         if slot_count > 0 {
             if buf.remaining() < 2 + (3 * slot_count) {
                 return Err(DecodeError::NotEnoughBytes);

--- a/src/mac/beacon.rs
+++ b/src/mac/beacon.rs
@@ -5,7 +5,8 @@
 use core::convert::From;
 use core::mem;
 
-use crate::mac::{DecodeError, ExtendedAddress, ShortAddress};
+use crate::mac::frame::DecodeError;
+use crate::mac::header::{ExtendedAddress, ShortAddress};
 
 use bytes::{Buf, BufMut};
 

--- a/src/mac/beacon.rs
+++ b/src/mac/beacon.rs
@@ -1,5 +1,5 @@
 //! Beacon
-//! 
+//!
 //! Work in progress
 
 use core::convert::From;
@@ -22,7 +22,7 @@ impl From<u8> for BeaconOrder {
     /// Convert u8 to beacon order
     fn from(value: u8) -> Self {
         match value {
-            0 ..= 14 => BeaconOrder::BeaconOrder(value),
+            0..=14 => BeaconOrder::BeaconOrder(value),
             _ => BeaconOrder::OnDemand,
         }
     }
@@ -53,7 +53,7 @@ impl From<u8> for SuperframeOrder {
     /// Convert u8 to superframe order
     fn from(value: u8) -> Self {
         match value {
-            0 ..= 14 => SuperframeOrder::SuperframeOrder(value),
+            0..=14 => SuperframeOrder::SuperframeOrder(value),
             _ => SuperframeOrder::Inactive,
         }
     }
@@ -329,7 +329,14 @@ impl GuaranteedTimeSlotInformation {
                 slots[n] = slot;
             }
         }
-        Ok((GuaranteedTimeSlotInformation { permit, slot_count, slots }, offset))
+        Ok((
+            GuaranteedTimeSlotInformation {
+                permit,
+                slot_count,
+                slots,
+            },
+            offset,
+        ))
     }
     /// Encode guaranteed time slot information into a byte buffer
     ///
@@ -502,7 +509,7 @@ impl PendingAddress {
         &self.extended_addresses[..self.extended_address_count]
     }
 }
- /// Beacon frame
+/// Beacon frame
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Beacon {
     /// Superframe specification
@@ -624,15 +631,20 @@ mod tests {
         assert_eq!(beacon.pending_address.short_addresses().len(), 0);
         assert_eq!(beacon.pending_address.extended_addresses().len(), 0);
 
-        let data = [0x12, 0xc3, 0x82, 0x01, 0x34, 0x12, 0x11, 0x78, 0x56,
-            0x14, 0x00];
+        let data = [
+            0x12, 0xc3, 0x82, 0x01, 0x34, 0x12, 0x11, 0x78, 0x56, 0x14, 0x00,
+        ];
         let (beacon, size) = Beacon::decode(&data).unwrap();
         assert_eq!(size, 11);
 
-        assert_eq!(beacon.superframe_spec.beacon_order,
-            BeaconOrder::BeaconOrder(2));
-        assert_eq!(beacon.superframe_spec.superframe_order,
-            SuperframeOrder::SuperframeOrder(1));
+        assert_eq!(
+            beacon.superframe_spec.beacon_order,
+            BeaconOrder::BeaconOrder(2)
+        );
+        assert_eq!(
+            beacon.superframe_spec.superframe_order,
+            SuperframeOrder::SuperframeOrder(1)
+        );
         assert_eq!(beacon.superframe_spec.final_cap_slot, 3);
         assert_eq!(beacon.superframe_spec.battery_life_extension, false);
         assert_eq!(beacon.superframe_spec.pan_coordinator, true);
@@ -653,16 +665,21 @@ mod tests {
         assert_eq!(beacon.pending_address.short_addresses().len(), 0);
         assert_eq!(beacon.pending_address.extended_addresses().len(), 0);
 
-        let data = [0x12, 0xc3, 0x82, 0x02, 0x34, 0x12, 0x11, 0x78, 0x56,
-            0x14, 0x12, 0x34, 0x12, 0x78, 0x56, 0xef, 0xcd, 0xab, 0x89, 0x67,
-            0x45, 0x23, 0x01];
+        let data = [
+            0x12, 0xc3, 0x82, 0x02, 0x34, 0x12, 0x11, 0x78, 0x56, 0x14, 0x12, 0x34, 0x12, 0x78,
+            0x56, 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01,
+        ];
         let (beacon, size) = Beacon::decode(&data).unwrap();
         assert_eq!(size, 23);
 
-        assert_eq!(beacon.superframe_spec.beacon_order,
-            BeaconOrder::BeaconOrder(2));
-        assert_eq!(beacon.superframe_spec.superframe_order,
-            SuperframeOrder::SuperframeOrder(1));
+        assert_eq!(
+            beacon.superframe_spec.beacon_order,
+            BeaconOrder::BeaconOrder(2)
+        );
+        assert_eq!(
+            beacon.superframe_spec.superframe_order,
+            SuperframeOrder::SuperframeOrder(1)
+        );
         assert_eq!(beacon.superframe_spec.final_cap_slot, 3);
         assert_eq!(beacon.superframe_spec.battery_life_extension, false);
         assert_eq!(beacon.superframe_spec.pan_coordinator, true);
@@ -681,18 +698,23 @@ mod tests {
         assert_eq!(slots[1].direction, Direction::Transmit);
 
         assert_eq!(beacon.pending_address.short_addresses().len(), 2);
-        assert_eq!(beacon.pending_address.short_addresses()[0],
-            ShortAddress(0x1234));
-        assert_eq!(beacon.pending_address.short_addresses()[1],
-            ShortAddress(0x5678));
+        assert_eq!(
+            beacon.pending_address.short_addresses()[0],
+            ShortAddress(0x1234)
+        );
+        assert_eq!(
+            beacon.pending_address.short_addresses()[1],
+            ShortAddress(0x5678)
+        );
         assert_eq!(beacon.pending_address.extended_addresses().len(), 1);
-        assert_eq!(beacon.pending_address.extended_addresses()[0],
-            ExtendedAddress(0x0123456789abcdef));
+        assert_eq!(
+            beacon.pending_address.extended_addresses()[0],
+            ExtendedAddress(0x0123456789abcdef)
+        );
     }
 
     #[test]
     fn encode_beacon() {
-
         let superframe_spec = SuperframeSpecification {
             beacon_order: BeaconOrder::OnDemand,
             superframe_order: SuperframeOrder::Inactive,
@@ -737,8 +759,12 @@ mod tests {
         let mut buffer = [0u8; 128];
         let size = beacon.encode(&mut buffer);
         assert_eq!(size, 18);
-        assert_eq!(buffer[..size], [0xff, 0xc0, 0x81, 0x01, 0x34, 0x12,
-            0x11, 0x11, 0x56, 0x78, 0x60, 0xe2, 0x16, 0x21, 0x1c, 0x4a,
-            0xc2, 0xae]);
+        assert_eq!(
+            buffer[..size],
+            [
+                0xff, 0xc0, 0x81, 0x01, 0x34, 0x12, 0x11, 0x11, 0x56, 0x78, 0x60, 0xe2, 0x16, 0x21,
+                0x1c, 0x4a, 0xc2, 0xae
+            ]
+        );
     }
 }

--- a/src/mac/beacon.rs
+++ b/src/mac/beacon.rs
@@ -5,8 +5,7 @@
 use core::convert::From;
 use core::mem;
 
-use crate::mac::frame::DecodeError;
-use crate::mac::header::{ExtendedAddress, ShortAddress};
+use crate::mac::{DecodeError, ExtendedAddress, ShortAddress};
 
 use bytes::{Buf, BufMut};
 

--- a/src/mac/command.rs
+++ b/src/mac/command.rs
@@ -18,7 +18,7 @@ extended_enum!(
     DataRequest => 4,
     /// PAN identifier conflict notification, sent from coordinator to offending device
     PanIdConflictNotification => 5,
-    /// Orphan notification, 
+    /// Orphan notification,
     OrphanNotification => 6,
     /// Beacon request, sent from a device which want to join a PAN
     BeaconRequest => 7,

--- a/src/mac/command.rs
+++ b/src/mac/command.rs
@@ -2,7 +2,10 @@
 //!
 //! Work in progress
 
-use crate::mac::{DecodeError, PanId, ShortAddress};
+use crate::mac::frame::{
+    header::{PanId, ShortAddress},
+    DecodeError,
+};
 use crate::utils::OptionalFrom;
 
 use bytes::{Buf, BufMut};

--- a/src/mac/command.rs
+++ b/src/mac/command.rs
@@ -185,7 +185,6 @@ impl CoordinatorRealignmentData {
     /// # Panics
     ///
     /// Panics if the buffer is not long enough to hold the frame.
-    ///
     pub fn encode(&self, buf: &mut [u8]) -> usize {
         let mut offset = 0;
         let size = self.pan_id.encode(buf);
@@ -345,7 +344,6 @@ impl Command {
     /// # Panics
     ///
     /// Panics if the buffer is not long enough to hold the frame.
-    ///
     pub fn encode(&self, buf: &mut [u8]) -> usize {
         match *self {
             Command::AssociationRequest(capability) => {

--- a/src/mac/frame/frame_control.rs
+++ b/src/mac/frame/frame_control.rs
@@ -5,6 +5,8 @@ use super::DecodeError;
 /// Defines the type of a MAC frame
 ///
 /// Part of [`Header`].
+///
+/// [`Header`]: super::header::Header
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum FrameType {
     /// Beacon
@@ -154,6 +156,8 @@ impl AddressMode {
 ///
 /// Part of [`Header`]. Auxiliary security headers are currently unsupported by
 /// this implementation.
+///
+/// [`Header`]: super::header::Header
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Security {
     /// No auxiliary security header is present

--- a/src/mac/frame/frame_control.rs
+++ b/src/mac/frame/frame_control.rs
@@ -165,41 +165,41 @@ pub struct FrameControl {
 }
 
 mod offset {
-    pub const frame_type: u16 = 0;
-    pub const security: u16 = 3;
-    pub const pending: u16 = 4;
-    pub const ack: u16 = 5;
-    pub const pan_id_compress: u16 = 6;
-    pub const dest_addr_mode: u16 = 10;
-    pub const version: u16 = 12;
-    pub const src_addr_mode: u16 = 14u16;
+    pub const FRAME_TYPE: u16 = 0;
+    pub const SECURITY: u16 = 3;
+    pub const PENDING: u16 = 4;
+    pub const ACK: u16 = 5;
+    pub const PAN_ID_COMPRESS: u16 = 6;
+    pub const DEST_ADDR_MODE: u16 = 10;
+    pub const VERSION: u16 = 12;
+    pub const SRC_ADDR_MODE: u16 = 14u16;
 }
 
 mod mask {
-    pub const frame_type: u16 = 0x0007;
-    pub const security: u16 = 0x0008;
-    pub const pending: u16 = 0x0010;
-    pub const ack: u16 = 0x0020;
-    pub const pan_id_compress: u16 = 0x0040;
-    pub const dest_addr_mode: u16 = 0x0C00;
-    pub const version: u16 = 0x3000;
-    pub const src_addr_mode: u16 = 0xC000;
+    pub const FRAME_TYPE: u16 = 0x0007;
+    pub const SECURITY: u16 = 0x0008;
+    pub const PENDING: u16 = 0x0010;
+    pub const ACK: u16 = 0x0020;
+    pub const PAN_ID_COMPRESS: u16 = 0x0040;
+    pub const DEST_ADDR_MODE: u16 = 0x0C00;
+    pub const VERSION: u16 = 0x3000;
+    pub const SRC_ADDR_MODE: u16 = 0xC000;
 }
 
 impl FrameControl {
     /// Try converrt from bits into FrameControl
     pub fn try_from_bits(bits: u16) -> Result<Self, DecodeError> {
         /* Parse raw data */
-        let frame_type = ((bits & mask::frame_type) >> offset::frame_type) as u8;
-        let security = ((bits & mask::security) >> offset::security) as u8;
+        let frame_type = ((bits & mask::FRAME_TYPE) >> offset::FRAME_TYPE) as u8;
+        let security = ((bits & mask::SECURITY) >> offset::SECURITY) as u8;
 
-        let frame_pending = ((bits & mask::pending) >> offset::pending) as u8;
-        let ack_request = ((bits & mask::ack) >> offset::ack) as u8;
-        let pan_id_compress = ((bits & mask::pan_id_compress) >> offset::pan_id_compress) as u8;
+        let frame_pending = ((bits & mask::PENDING) >> offset::PENDING) as u8;
+        let ack_request = ((bits & mask::ACK) >> offset::ACK) as u8;
+        let pan_id_compress = ((bits & mask::PAN_ID_COMPRESS) >> offset::PAN_ID_COMPRESS) as u8;
 
-        let dest_addr_mode = ((bits & mask::dest_addr_mode) >> offset::dest_addr_mode) as u8;
-        let version = ((bits & mask::version) >> offset::version) as u8;
-        let src_addr_mode = ((bits & mask::src_addr_mode) >> offset::src_addr_mode) as u8;
+        let dest_addr_mode = ((bits & mask::DEST_ADDR_MODE) >> offset::DEST_ADDR_MODE) as u8;
+        let version = ((bits & mask::VERSION) >> offset::VERSION) as u8;
+        let src_addr_mode = ((bits & mask::SRC_ADDR_MODE) >> offset::SRC_ADDR_MODE) as u8;
 
         /* Make rust struct */
         let version =
@@ -228,14 +228,14 @@ impl FrameControl {
 
     /// Convert Frame Control into bits.
     pub fn to_bits(&self) -> u16 {
-        let frame_control = (self.frame_type as u16) << offset::frame_type
-            | (self.security as u16) << offset::security
-            | (self.frame_pending as u16) << offset::pending
-            | (self.ack_request as u16) << offset::ack
-            | (self.pan_id_compress as u16) << offset::pan_id_compress
-            | (self.dest_addr_mode as u16) << offset::dest_addr_mode
-            | (self.version as u16) << offset::version
-            | (self.src_addr_mode as u16) << offset::src_addr_mode;
+        let frame_control = (self.frame_type as u16) << offset::FRAME_TYPE
+            | (self.security as u16) << offset::SECURITY
+            | (self.frame_pending as u16) << offset::PENDING
+            | (self.ack_request as u16) << offset::ACK
+            | (self.pan_id_compress as u16) << offset::PAN_ID_COMPRESS
+            | (self.dest_addr_mode as u16) << offset::DEST_ADDR_MODE
+            | (self.version as u16) << offset::VERSION
+            | (self.src_addr_mode as u16) << offset::SRC_ADDR_MODE;
 
         frame_control
     }

--- a/src/mac/frame/frame_control.rs
+++ b/src/mac/frame/frame_control.rs
@@ -28,7 +28,7 @@ impl FrameType {
     /// # Example
     ///
     /// ``` rust
-    /// use ieee802154::mac::header::FrameType;
+    /// use ieee802154::mac::FrameType;
     ///
     /// let frame_type = FrameType::from_bits(0b001);
     /// assert_eq!(frame_type, Some(FrameType::Data));
@@ -64,7 +64,7 @@ impl FrameVersion {
     /// # Example
     ///
     /// ``` rust
-    /// use ieee802154::mac::header::FrameVersion;
+    /// use ieee802154::mac::FrameVersion;
     ///
     /// let version = FrameVersion::from_bits(0b0);
     /// assert_eq!(version, Some(FrameVersion::Ieee802154_2003));
@@ -83,7 +83,7 @@ impl FrameVersion {
 ///
 /// # Example
 /// ```rust
-/// use ieee802154::mac::header::{Address, AddressMode, PanId, ShortAddress};
+/// use ieee802154::mac::{Address, AddressMode, PanId, ShortAddress};
 ///
 /// let example_addr = Some(Address::Short(PanId(0x3412), ShortAddress(0x7856)));
 /// let address_mode = AddressMode::from(example_addr);
@@ -127,7 +127,7 @@ impl AddressMode {
     /// # Example
     ///
     /// ``` rust
-    /// use ieee802154::mac::header::AddressMode;
+    /// use ieee802154::mac::AddressMode;
     /// // decode
     /// let address_mode = AddressMode::from_bits(0b10).unwrap();
     /// assert_eq!(address_mode, AddressMode::Short);

--- a/src/mac/frame/frame_control.rs
+++ b/src/mac/frame/frame_control.rs
@@ -1,0 +1,262 @@
+//! This module contains definition of Frame Control field that is defined int 5.2.1.1 section.
+use super::DecodeError;
+
+/// Defines the type of a MAC frame
+///
+/// Part of [`Header`].
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum FrameType {
+    /// Beacon
+    Beacon = 0b000,
+
+    /// Data
+    Data = 0b001,
+
+    /// Acknowledgement
+    Acknowledgement = 0b010,
+
+    /// MAC command
+    MacCommand = 0b011,
+}
+
+impl FrameType {
+    /// Creates an instance of [`FrameType`] from the provided bits
+    ///
+    /// Returns `None`, if the provided bits don't encode a valid frame type.
+    ///
+    /// # Example
+    ///
+    /// ``` rust
+    /// use ieee802154::mac::FrameType;
+    ///
+    /// let frame_type = FrameType::from_bits(0b001);
+    /// assert_eq!(frame_type, Some(FrameType::Data));
+    /// ```
+    pub fn from_bits(bits: u8) -> Option<Self> {
+        match bits {
+            0b000 => Some(FrameType::Beacon),
+            0b001 => Some(FrameType::Data),
+            0b010 => Some(FrameType::Acknowledgement),
+            0b011 => Some(FrameType::MacCommand),
+            _ => None,
+        }
+    }
+}
+
+/// Defines version information for a frame
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum FrameVersion {
+    /// A frame conforming to the 802.15.4-2003 standard
+    Ieee802154_2003 = 0b00,
+    /// A frame conforming to the 802.15.4-2006 standard
+    Ieee802154_2006 = 0b01,
+    /// A frame conforming to the current 802.15.4 standard
+    Ieee802154 = 0b10,
+}
+
+impl FrameVersion {
+    /// Creates an instance of [`FrameVersion`] from the provided bits
+    ///
+    /// Returns `None`, if the provided bits don't encode a valid value of
+    /// `FrameVersion`.
+    ///
+    /// # Example
+    ///
+    /// ``` rust
+    /// use ieee802154::mac::FrameVersion;
+    ///
+    /// let version = FrameVersion::from_bits(0b0);
+    /// assert_eq!(version, Some(FrameVersion::Ieee802154_2003));
+    /// ```
+    pub fn from_bits(bits: u8) -> Option<Self> {
+        match bits {
+            0b00 => Some(FrameVersion::Ieee802154_2003),
+            0b01 => Some(FrameVersion::Ieee802154_2006),
+            0b10 => Some(FrameVersion::Ieee802154),
+            _ => None,
+        }
+    }
+}
+
+/// Defines the type of Address
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum AddressMode {
+    /// PAN identifier and address field are not present
+    None = 0b00,
+    /// Address field contains a 16 bit short address
+    Short = 0b10,
+    /// Address field contains a 64 bit extended address
+    Extended = 0b11,
+}
+
+impl AddressMode {
+    /// Creates an instance of [`AddressMode`] from the provided bits
+    ///
+    /// Returns `None`, if the provided bits don't encode a valid value of
+    /// `AddressMode`.
+    ///
+    /// # Example
+    ///
+    /// ``` rust
+    /// use ieee802154::mac::AddressMode;
+    ///
+    /// let address_mode = AddressMode::from_bits(0b10).unwrap();
+    /// assert_eq!(address_mode, AddressMode::Short);
+    /// ```
+    pub fn from_bits(bits: u8) -> Result<Self, DecodeError> {
+        match bits {
+            0b00 => Ok(AddressMode::None),
+            0b10 => Ok(AddressMode::Short),
+            0b11 => Ok(AddressMode::Extended),
+            _ => Err(DecodeError::InvalidAddressMode(bits)),
+        }
+    }
+
+    pub(crate) fn as_u8(self) -> u8 {
+        match self {
+            Self::None => 0,
+            Self::Short => 0b10,
+            Self::Extended => 0b11,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+/// Frame Control begin of MAC header
+pub struct FrameControl {
+    /// Frame Type
+    pub frame_type: FrameType,
+
+    /// Auxiliary Security header
+    pub security: bool,
+
+    /// Frame Pending
+    ///
+    /// The Frame Pending field shall be set to `true` if the device sending the frame has more data
+    /// for the recipient,as described in 5.1.6.3. This field shall be set to `false` otherwise.
+    pub frame_pending: bool,
+
+    /// Acknowledgement Request
+    ///
+    /// The AR field specifies whether an acknowledgment is required from the recipient device on receipt of a data
+    /// or MAC command frame. If this field is set to `true`, the recipient device shall send an acknowledgment frame
+    /// only if, upon reception, the frame passes the filtering described in 5.1.6.2. If this field is set to `false`, the
+    /// recipient device shall not send an acknowledgment frame.
+    pub ack_request: bool,
+
+    /// PAN ID Compress
+    ///
+    /// The PAN ID Compression field specifies whether the MAC frame is to be sent containing only one of the
+    /// PAN identifier fields when both src and destination addresses are present. If this field is set to `true` and
+    /// both  the  src  and  destination  addresses  are  present,  the  frame  shall  contain  only  the  Destination  PAN
+    /// Identifier field, and the Source PAN Identifier field shall be assumed equal to that of the destination. If this
+    /// field is set to `false`, then the PAN Identifier field shall be present if and only if the corresponding address is
+    /// present.
+    pub pan_id_compress: bool,
+
+    /// Destination address mode
+    pub dest_addr_mode: AddressMode,
+
+    /// Frame version
+    pub version: FrameVersion,
+
+    /// Source address mode
+    pub src_addr_mode: AddressMode,
+}
+
+mod offset {
+    pub const frame_type: u16 = 0;
+    pub const security: u16 = 3;
+    pub const pending: u16 = 4;
+    pub const ack: u16 = 5;
+    pub const pan_id_compress: u16 = 6;
+    pub const dest_addr_mode: u16 = 10;
+    pub const version: u16 = 12;
+    pub const src_addr_mode: u16 = 14u16;
+}
+
+mod mask {
+    pub const frame_type: u16 = 0x0007;
+    pub const security: u16 = 0x0008;
+    pub const pending: u16 = 0x0010;
+    pub const ack: u16 = 0x0020;
+    pub const pan_id_compress: u16 = 0x0040;
+    pub const dest_addr_mode: u16 = 0x0C00;
+    pub const version: u16 = 0x3000;
+    pub const src_addr_mode: u16 = 0xC000;
+}
+
+impl FrameControl {
+    /// Try converrt from bits into FrameControl
+    pub fn try_from_bits(bits: u16) -> Result<Self, DecodeError> {
+        /* Parse raw data */
+        let frame_type = ((bits & mask::frame_type) >> offset::frame_type) as u8;
+        let security = ((bits & mask::security) >> offset::security) as u8;
+
+        let frame_pending = ((bits & mask::pending) >> offset::pending) as u8;
+        let ack_request = ((bits & mask::ack) >> offset::ack) as u8;
+        let pan_id_compress = ((bits & mask::pan_id_compress) >> offset::pan_id_compress) as u8;
+
+        let dest_addr_mode = ((bits & mask::dest_addr_mode) >> offset::dest_addr_mode) as u8;
+        let version = ((bits & mask::version) >> offset::version) as u8;
+        let src_addr_mode = ((bits & mask::src_addr_mode) >> offset::src_addr_mode) as u8;
+
+        /* Make rust struct */
+        let version =
+            FrameVersion::from_bits(version).ok_or(DecodeError::InvalidFrameVersion(version))?;
+        let frame_type =
+            FrameType::from_bits(frame_type).ok_or(DecodeError::InvalidFrameType(frame_type))?;
+        let dest_addr_mode = AddressMode::from_bits(dest_addr_mode)?;
+        let src_addr_mode = AddressMode::from_bits(src_addr_mode)?;
+        // make bool values
+        let security = security > 0;
+        let frame_pending = frame_pending > 0;
+        let ack_request = ack_request > 0;
+        let pan_id_compress = pan_id_compress > 0;
+
+        Ok(Self {
+            frame_type,
+            security,
+            frame_pending,
+            ack_request,
+            pan_id_compress,
+            dest_addr_mode,
+            version,
+            src_addr_mode,
+        })
+    }
+
+    /// Convert Frame Control into bits.
+    pub fn to_bits(&self) -> u16 {
+        let frame_control = (self.frame_type as u16) << offset::frame_type
+            | (self.security as u16) << offset::security
+            | (self.frame_pending as u16) << offset::pending
+            | (self.ack_request as u16) << offset::ack
+            | (self.pan_id_compress as u16) << offset::pan_id_compress
+            | (self.dest_addr_mode as u16) << offset::dest_addr_mode
+            | (self.version as u16) << offset::version
+            | (self.src_addr_mode as u16) << offset::src_addr_mode;
+
+        frame_control
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Buf;
+
+    #[test]
+    fn frame_control_from_bits() {
+        let mut fctl_bytes = &[0x00, 0x10][..];
+        let fctl = FrameControl::try_from_bits(fctl_bytes.get_u16_le()).expect("correct bytes");
+        assert_eq!(fctl.frame_type, FrameType::Beacon);
+        assert_eq!(fctl.version, FrameVersion::Ieee802154_2006);
+        assert_eq!(fctl.security, false);
+        assert_eq!(fctl.frame_pending, false);
+        assert_eq!(fctl.ack_request, false);
+        assert_eq!(fctl.pan_id_compress, false);
+        assert_eq!(fctl.src_addr_mode, AddressMode::None);
+        assert_eq!(fctl.dest_addr_mode, AddressMode::None);
+    }
+}

--- a/src/mac/frame/header.rs
+++ b/src/mac/frame/header.rs
@@ -69,9 +69,9 @@ pub struct Header {
 }
 
 impl Header {
-    /// Decodes a header from a byte buffer
+    /// Decodes a mac header from a byte buffer.
     ///
-    /// This method is used by [`Frame::decode`] to decode the frame header.
+    /// This method is used by [`Frame::decode`] to decode the mac header.
     /// Unless you decide to write your own code for decoding frames, there
     /// should be no reason to call this method directly.
     ///
@@ -124,6 +124,8 @@ impl Header {
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// [`Frame::decode`]: super::Frame
     pub fn decode(buf: &mut dyn Buf) -> Result<Self, DecodeError> {
         // Make sure we have enough buffer for the Frame Control field
         if buf.remaining() < 3 {

--- a/src/mac/frame/header.rs
+++ b/src/mac/frame/header.rs
@@ -1,0 +1,556 @@
+//! Partial implementation of the IEEE 802.15.4 frame Header
+//!
+//! The main type in this module is [`Header`], the header of 802.15.4 MAC frame.
+//!
+//! [`Header`]: struct.Header.html
+use bytes::{Buf, BufMut};
+use hash32_derive::Hash32;
+
+use super::frame_control::*;
+pub use super::frame_control::{AddressMode, FrameType, FrameVersion, Security};
+use super::DecodeError;
+
+/// MAC frame header
+///
+/// External documentation for [MAC frame format start at 5.2]
+///
+/// [MAC frame format start at 5.2]: http://ecee.colorado.edu/~liue/teaching/comm_standards/2015S_zigbee/802.15.4-2011.pdf
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct Header {
+    // * Frame Control Field * /
+    /// Frame Type
+    pub frame_type: FrameType,
+
+    /// Auxiliary Security header
+    pub security: Security,
+
+    /// Frame Pending
+    ///
+    /// The Frame Pending field shall be set to `true` if the device sending the frame has more data
+    /// for the recipient,as described in 5.1.6.3. This field shall be set to `false` otherwise.
+    pub frame_pending: bool,
+
+    /// Acknowledgement Request
+    ///
+    /// The AR field specifies whether an acknowledgment is required from the recipient device on receipt of a data
+    /// or MAC command frame. If this field is set to `true`, the recipient device shall send an acknowledgment frame
+    /// only if, upon reception, the frame passes the filtering described in 5.1.6.2. If this field is set to `false`, the
+    /// recipient device shall not send an acknowledgment frame.
+    pub ack_request: bool,
+
+    /// PAN ID Compress
+    ///
+    /// The PAN ID Compression field specifies whether the MAC frame is to be sent containing only one of the
+    /// PAN identifier fields when both src and destination addresses are present. If this field is set to `true` and
+    /// both  the  src  and  destination  addresses  are  present,  the  frame  shall  contain  only  the  Destination  PAN
+    /// Identifier field, and the Source PAN Identifier field shall be assumed equal to that of the destination. If this
+    /// field is set to `false`, then the PAN Identifier field shall be present if and only if the corresponding address is
+    /// present.
+    pub pan_id_compress: bool,
+
+    /// Frame version
+    pub version: FrameVersion,
+
+    // Destination address mode
+    // use `destination` to determinate AddressMode
+
+    // Source address mode
+    // use `source` to determinate AddressMode
+
+    // * End of Frame Control Field */
+    /// Sequence Number
+    pub seq: u8,
+
+    /// Destination Address
+    pub destination: Option<Address>,
+
+    /// Source Address
+    pub source: Option<Address>,
+}
+
+impl Header {
+    /// Decodes a header from a byte buffer
+    ///
+    /// This method is used by [`Frame::decode`] to decode the frame header.
+    /// Unless you decide to write your own code for decoding frames, there
+    /// should be no reason to call this method directly.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error, if the bytes either don't encode a valid
+    /// IEEE 802.15.4 frame header, or encode a frame header that is not fully
+    /// supported by this implementation. Please refer to [`DecodeError`] for
+    /// details.
+    ///
+    /// # Example
+    ///
+    /// ``` rust
+    /// use ieee802154::mac::header::{
+    ///     Address,
+    ///     ShortAddress,
+    ///     FrameType,
+    ///     Header,
+    ///     PanId,
+    ///     Security,
+    /// };
+    ///
+    /// # fn main() -> Result<(), ::ieee802154::mac::frame::DecodeError> {
+    /// // Construct a simple header.
+    /// let mut bytes = &[
+    ///     0x01, 0x98,             // frame control
+    ///     0x00,                   // sequence number
+    ///     0x12, 0x34, 0x56, 0x78, // PAN identifier and address of destination
+    ///     0x12, 0x34, 0x9a, 0xbc, // PAN identifier and address of source
+    /// ][..];
+    ///
+    /// let header = Header::decode(&mut bytes)?;
+    ///
+    /// assert_eq!(header.frame_type,      FrameType::Data);
+    /// assert_eq!(header.security,        Security::None);
+    /// assert_eq!(header.frame_pending,   false);
+    /// assert_eq!(header.ack_request,     false);
+    /// assert_eq!(header.pan_id_compress, false);
+    /// assert_eq!(header.seq,             0x00);
+    ///
+    /// assert_eq!(
+    ///     header.destination,
+    ///     Some(Address::Short(PanId(0x3412), ShortAddress(0x7856)))
+    /// );
+    /// assert_eq!(
+    ///     header.source,
+    ///     Some(Address::Short(PanId(0x3412), ShortAddress(0xbc9a)))
+    /// );
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn decode(buf: &mut dyn Buf) -> Result<Self, DecodeError> {
+        // Make sure we have enough buffer for the Frame Control field
+        if buf.remaining() < 3 {
+            return Err(DecodeError::NotEnoughBytes);
+        }
+
+        /* Decode Frame Control Field */
+        let bits = buf.get_u16_le();
+
+        let frame_type = ((bits & mask::FRAME_TYPE) >> offset::FRAME_TYPE) as u8;
+        let security = ((bits & mask::SECURITY) >> offset::SECURITY) as u8;
+
+        let frame_pending = ((bits & mask::PENDING) >> offset::PENDING) as u8;
+        let ack_request = ((bits & mask::ACK) >> offset::ACK) as u8;
+        let pan_id_compress = ((bits & mask::PAN_ID_COMPRESS) >> offset::PAN_ID_COMPRESS) as u8;
+
+        let dest_addr_mode = ((bits & mask::DEST_ADDR_MODE) >> offset::DEST_ADDR_MODE) as u8;
+        let version = ((bits & mask::VERSION) >> offset::VERSION) as u8;
+        let src_addr_mode = ((bits & mask::SRC_ADDR_MODE) >> offset::SRC_ADDR_MODE) as u8;
+
+        let version =
+            FrameVersion::from_bits(version).ok_or(DecodeError::InvalidFrameVersion(version))?;
+        let frame_type =
+            FrameType::from_bits(frame_type).ok_or(DecodeError::InvalidFrameType(frame_type))?;
+        let dest_addr_mode = AddressMode::from_bits(dest_addr_mode)?;
+        let src_addr_mode = AddressMode::from_bits(src_addr_mode)?;
+
+        // make bool values
+        let security = if security > 0 {
+            return Err(DecodeError::SecurityNotSupported);
+        } else {
+            Security::None
+        };
+        let frame_pending = frame_pending > 0;
+        let ack_request = ack_request > 0;
+        let pan_id_compress = pan_id_compress > 0;
+
+        /* Decode header depending on Frame Control Fields */
+
+        let seq = buf.get_u8();
+
+        let destination = Address::decode(buf, &dest_addr_mode)?;
+
+        let source = if !pan_id_compress {
+            Address::decode(buf, &src_addr_mode)?
+        } else {
+            let pan_id = destination
+                .ok_or(DecodeError::InvalidAddressMode(dest_addr_mode.as_u8()))?
+                .pan_id();
+            Address::decode_compress(buf, &src_addr_mode, pan_id)?
+        };
+
+        let header = Header {
+            frame_type,
+            security,
+            frame_pending,
+            ack_request,
+            pan_id_compress,
+            version,
+
+            seq,
+            destination,
+            source,
+        };
+
+        Ok(header)
+    }
+
+    /// Encodes the header into a buffer
+    ///
+    /// The header length depends on the options chosen and varies between 3 and
+    /// 30 octets.
+    ///
+    /// # Example
+    ///
+    /// ``` rust
+    /// use bytes::BytesMut;
+    /// use ieee802154::mac::header::{
+    ///     Address,
+    ///     AddressMode,
+    ///     ShortAddress,
+    ///     FrameType,
+    ///     FrameVersion,
+    ///     Header,
+    ///     PanId,
+    ///     Security,
+    /// };
+    ///
+    /// let header = Header {
+    ///     frame_type:      FrameType::Data,
+    ///     security:        Security::None,
+    ///     frame_pending:   false,
+    ///     ack_request:     false,
+    ///     pan_id_compress: false,
+    ///     version:         FrameVersion::Ieee802154_2006,
+    ///     seq:             0x00,
+    ///
+    ///     destination: Some(Address::Short(PanId(0x1234), ShortAddress(0x5678))),
+    ///     source:      Some(Address::Short(PanId(0x1234), ShortAddress(0x9abc))),
+    /// };
+    ///
+    /// let mut bytes = BytesMut::with_capacity(11);
+    ///
+    /// header.encode(&mut bytes);
+    /// let encoded_bytes = bytes.split().freeze();
+    ///
+    /// let expected_bytes = [
+    ///     0x01, 0x98,             // frame control
+    ///     0x00,                   // sequence number
+    ///     0x34, 0x12, 0x78, 0x56, // PAN identifier and address of destination
+    ///     0x34, 0x12, 0xbc, 0x9a, // PAN identifier and address of source
+    /// ];
+    /// assert_eq!(encoded_bytes, expected_bytes[..]);
+    /// ```
+    pub fn encode(&self, buf: &mut dyn BufMut) {
+        /* Encode Frame Control fields */
+        let dest_addr_mode = AddressMode::from(self.destination);
+        let src_addr_mode = AddressMode::from(self.source);
+
+        let frame_control_raw = (self.frame_type as u16) << offset::FRAME_TYPE
+            | (self.security as u16) << offset::SECURITY
+            | (self.frame_pending as u16) << offset::PENDING
+            | (self.ack_request as u16) << offset::ACK
+            | (self.pan_id_compress as u16) << offset::PAN_ID_COMPRESS
+            | (dest_addr_mode as u16) << offset::DEST_ADDR_MODE
+            | (self.version as u16) << offset::VERSION
+            | (src_addr_mode as u16) << offset::SRC_ADDR_MODE;
+
+        buf.put_u16_le(frame_control_raw);
+
+        // Write Sequence Number
+        buf.put_u8(self.seq);
+
+        // Write addresses
+        if let Some(destination) = self.destination {
+            destination.encode(buf);
+        }
+
+        match (self.source, self.pan_id_compress) {
+            (Some(source), true) => {
+                source.encode_compress(buf);
+            }
+            (Some(source), false) => {
+                source.encode(buf);
+            }
+            (None, true) => {
+                panic!("frame control request compress source address without contain this address")
+            }
+            (None, false) => (),
+        }
+    }
+}
+
+/// Personal Area Network Identifier
+///
+/// A 16-bit value that identifies a PAN
+///
+/// # Example
+///
+/// ``` rust
+/// use ieee802154::mac::header::PanId;
+///
+/// let pan_id = PanId(0x0123);
+/// ```
+#[derive(Clone, Copy, Debug, Eq, Hash, Hash32, PartialEq)]
+pub struct PanId(pub u16);
+
+impl PanId {
+    /// Get the broadcast PAN identifier
+    pub fn broadcast() -> Self {
+        Self(0xffff)
+    }
+
+    /// Decodes an PAN identifier from a byte buffer
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error, if there are not enough bytes in the
+    /// buffer to encode a valid `Address` instance.
+    ///
+    /// # Example
+    ///
+    /// ``` rust
+    /// use ieee802154::mac::header::PanId;
+    ///
+    /// # fn main() -> Result<(), ::ieee802154::mac::frame::DecodeError> {
+    /// let mut bytes = &[0x56, 0x78][..];
+    /// let address = PanId::decode(&mut bytes)?;
+    ///
+    /// assert_eq!(address.0, 0x7856);
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn decode(buf: &mut dyn Buf) -> Result<Self, DecodeError> {
+        if buf.remaining() < 2 {
+            return Err(DecodeError::NotEnoughBytes);
+        }
+
+        Ok(PanId(buf.get_u16_le()))
+    }
+
+    /// Encodes the PAN identifier into a buffer
+    ///
+    /// # Example
+    ///
+    /// ``` rust
+    /// use ieee802154::mac::header::PanId;
+    /// use bytes::BytesMut;
+    ///
+    /// let address = PanId(0x1234);
+    ///
+    /// let mut bytes = BytesMut::with_capacity(2);
+    /// address.encode(&mut bytes);
+    ///
+    /// let expected_bytes = [0x34, 0x12];
+    /// assert_eq!(bytes[..], expected_bytes[..]);
+    /// ```
+    pub fn encode(&self, buf: &mut dyn BufMut) {
+        buf.put_u16_le(self.0)
+    }
+}
+
+/// A 16-bit short address
+///
+/// Short address assigned to a device during association, used to identify the
+/// device in the PAN.
+///
+/// # Example
+///
+/// ``` rust
+/// use ieee802154::mac::header::ShortAddress;
+///
+/// let short_address = ShortAddress(0x0123);
+/// ```
+#[derive(Clone, Copy, Debug, Eq, Hash, Hash32, PartialEq)]
+pub struct ShortAddress(pub u16);
+
+impl ShortAddress {
+    /// An instance of `ShortAddress` that represents the broadcast address.
+    pub const BROADCAST: Self = ShortAddress(0xffff);
+
+    /// Creates an instance of `ShortAddress` that represents the broadcast address
+    pub fn broadcast() -> Self {
+        ShortAddress(0xffff)
+    }
+
+    /// Decodes an address from a byte buffer
+    ///
+    /// This method is used by [`Header::decode`] to decode addresses. Unless
+    /// you decide to write your own code for decoding headers, there should be
+    /// no reason to call this method directly.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error, if there are not enough bytes in the
+    /// buffer to encode a valid `Address` instance.
+    ///
+    /// # Example
+    ///
+    /// ``` rust
+    /// use ieee802154::mac::frame::{DecodeError, header::ShortAddress};
+    ///
+    /// # fn main() -> Result<(), DecodeError> {
+    /// let mut bytes = &[0x56, 0x78][..];
+    /// let address = ShortAddress::decode(&mut bytes)?;
+    ///
+    /// assert_eq!(address, ShortAddress(0x7856));
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn decode(buf: &mut dyn Buf) -> Result<Self, DecodeError> {
+        if buf.remaining() < 2 {
+            return Err(DecodeError::NotEnoughBytes);
+        }
+
+        Ok(ShortAddress(buf.get_u16_le()))
+    }
+
+    /// Encodes the address into a buffer
+    ///
+    /// # Example
+    ///
+    /// ``` rust
+    /// use ieee802154::mac::header::ShortAddress;
+    ///
+    /// let address = ShortAddress(0x5678);
+    ///
+    /// let mut bytes = bytes::BytesMut::with_capacity(2);
+    /// address.encode(&mut bytes);
+    ///
+    /// let expected_bytes = [0x78, 0x56];
+    /// assert_eq!(bytes[..], expected_bytes[..]);
+    /// ```
+    pub fn encode(&self, buf: &mut dyn BufMut) {
+        buf.put_u16_le(self.0)
+    }
+}
+
+/// A 64-bit extended address
+///
+/// A unique address that is used to identify an device in the PAN.
+///
+/// # Example
+///
+/// ``` rust
+/// use ieee802154::mac::header::ExtendedAddress;
+///
+/// let ext_address = ExtendedAddress(0x0123456789abcdef);
+/// ```
+#[derive(Clone, Copy, Debug, Eq, Hash, Hash32, PartialEq)]
+pub struct ExtendedAddress(pub u64);
+
+impl ExtendedAddress {
+    /// An instance of `ExtendedAddress` that represents the broadcast address.
+    pub const BROADCAST: Self = ExtendedAddress(0xffffffffffffffffu64);
+
+    /// Creates an instance of `ExtendedAddress` that represents the broadcast address
+    pub fn broadcast() -> Self {
+        ExtendedAddress(0xffffffffffffffffu64)
+    }
+
+    /// Decodes an address from a byte buffer
+    pub fn decode(buf: &mut dyn Buf) -> Result<Self, DecodeError> {
+        if buf.remaining() < 8 {
+            return Err(DecodeError::NotEnoughBytes);
+        }
+        Ok(ExtendedAddress(buf.get_u64_le()))
+    }
+
+    /// Encodes the address into a buffer
+    pub fn encode(&self, buf: &mut dyn BufMut) {
+        buf.put_u64_le(self.0)
+    }
+}
+
+/// An address that might contain an PAN ID and address
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Address {
+    /// Short (16-bit) address and PAN ID (16-bit)
+    Short(PanId, ShortAddress),
+    /// Extended (64-bit) address and PAN ID (16-bit)
+    Extended(PanId, ExtendedAddress),
+}
+
+impl Address {
+    /// Creates an instance of `Address` that represents the broadcast address
+    pub fn broadcast(mode: &AddressMode) -> Option<Self> {
+        match mode {
+            AddressMode::None => None,
+            AddressMode::Short => Some(Address::Short(
+                PanId::broadcast(),
+                ShortAddress::broadcast(),
+            )),
+            AddressMode::Extended => Some(Address::Extended(
+                PanId::broadcast(),
+                ExtendedAddress::broadcast(),
+            )),
+        }
+    }
+
+    /// Decodes an address from a byte buffer
+    pub fn decode(buf: &mut dyn Buf, mode: &AddressMode) -> Result<Option<Self>, DecodeError> {
+        let opt_address = match mode {
+            AddressMode::None => None,
+            AddressMode::Short => {
+                let pan_id = PanId::decode(buf)?;
+                let short = ShortAddress::decode(buf)?;
+                Some(Address::Short(pan_id, short))
+            }
+            AddressMode::Extended => {
+                let pan_id = PanId::decode(buf)?;
+                let extended = ExtendedAddress::decode(buf)?;
+                Some(Address::Extended(pan_id, extended))
+            }
+        };
+        Ok(opt_address)
+    }
+
+    /// Decodes an address from a byte buffer
+    pub fn decode_compress(
+        buf: &mut dyn Buf,
+        mode: &AddressMode,
+        pan_id: PanId,
+    ) -> Result<Option<Self>, DecodeError> {
+        let opt_address = match mode {
+            AddressMode::None => None,
+            AddressMode::Short => {
+                let short = ShortAddress::decode(buf)?;
+                Some(Address::Short(pan_id, short))
+            }
+            AddressMode::Extended => {
+                let extended = ExtendedAddress::decode(buf)?;
+                Some(Address::Extended(pan_id, extended))
+            }
+        };
+        Ok(opt_address)
+    }
+
+    /// Encodes the address into a buffer
+    pub fn encode(&self, buf: &mut dyn BufMut) {
+        match *self {
+            Address::Short(pan_id, short) => {
+                pan_id.encode(buf);
+                short.encode(buf);
+            }
+            Address::Extended(pan_id, extended) => {
+                pan_id.encode(buf);
+                extended.encode(buf);
+            }
+        }
+    }
+
+    /// Encodes the address into a buffer
+    pub fn encode_compress(&self, buf: &mut dyn BufMut) {
+        match *self {
+            Address::Short(_, a) => a.encode(buf),
+            Address::Extended(_, a) => a.encode(buf),
+        }
+    }
+
+    /// Get the PAN ID for this address
+    pub fn pan_id(&self) -> PanId {
+        match *self {
+            Address::Short(pan_id, _) => pan_id,
+            Address::Extended(pan_id, _) => pan_id,
+        }
+    }
+}

--- a/src/mac/frame/header.rs
+++ b/src/mac/frame/header.rs
@@ -85,7 +85,7 @@ impl Header {
     /// # Example
     ///
     /// ``` rust
-    /// use ieee802154::mac::header::{
+    /// use ieee802154::mac::{
     ///     Address,
     ///     ShortAddress,
     ///     FrameType,
@@ -201,7 +201,7 @@ impl Header {
     ///
     /// ``` rust
     /// use bytes::BytesMut;
-    /// use ieee802154::mac::header::{
+    /// use ieee802154::mac::{
     ///     Address,
     ///     AddressMode,
     ///     ShortAddress,
@@ -284,7 +284,7 @@ impl Header {
 /// # Example
 ///
 /// ``` rust
-/// use ieee802154::mac::header::PanId;
+/// use ieee802154::mac::PanId;
 ///
 /// let pan_id = PanId(0x0123);
 /// ```
@@ -307,7 +307,7 @@ impl PanId {
     /// # Example
     ///
     /// ``` rust
-    /// use ieee802154::mac::header::PanId;
+    /// use ieee802154::mac::PanId;
     ///
     /// # fn main() -> Result<(), ::ieee802154::mac::frame::DecodeError> {
     /// let mut bytes = &[0x56, 0x78][..];
@@ -331,7 +331,7 @@ impl PanId {
     /// # Example
     ///
     /// ``` rust
-    /// use ieee802154::mac::header::PanId;
+    /// use ieee802154::mac::PanId;
     /// use bytes::BytesMut;
     ///
     /// let address = PanId(0x1234);
@@ -355,7 +355,7 @@ impl PanId {
 /// # Example
 ///
 /// ``` rust
-/// use ieee802154::mac::header::ShortAddress;
+/// use ieee802154::mac::ShortAddress;
 ///
 /// let short_address = ShortAddress(0x0123);
 /// ```
@@ -409,7 +409,7 @@ impl ShortAddress {
     /// # Example
     ///
     /// ``` rust
-    /// use ieee802154::mac::header::ShortAddress;
+    /// use ieee802154::mac::ShortAddress;
     ///
     /// let address = ShortAddress(0x5678);
     ///
@@ -431,7 +431,7 @@ impl ShortAddress {
 /// # Example
 ///
 /// ``` rust
-/// use ieee802154::mac::header::ExtendedAddress;
+/// use ieee802154::mac::ExtendedAddress;
 ///
 /// let ext_address = ExtendedAddress(0x0123456789abcdef);
 /// ```

--- a/src/mac/frame/mod.rs
+++ b/src/mac/frame/mod.rs
@@ -151,19 +151,18 @@ impl<'p> Frame<'p> {
     /// # Example
     ///
     /// ``` rust
-    /// use ieee802154::mac::frame::{
+    /// use ieee802154::mac::{
     ///   Frame,
     ///   FrameContent,
     ///   WriteFooter,
-    ///   header::{
-    ///     Address,
-    ///     ShortAddress,
-    ///     FrameType,
-    ///     FrameVersion,
-    ///     Header,
-    ///     PanId,
-    ///     Security,
-    /// }};
+    ///   Address,
+    ///   ShortAddress,
+    ///   FrameType,
+    ///   FrameVersion,
+    ///   Header,
+    ///   PanId,
+    ///   Security,
+    /// };
     ///
     /// let frame = Frame {
     ///     header: Header {
@@ -294,9 +293,7 @@ mod tests {
     use super::*;
     use crate::mac::beacon;
     use crate::mac::command;
-    use crate::mac::header::{
-        Address, ExtendedAddress, FrameVersion, PanId, Security, ShortAddress,
-    };
+    use crate::mac::{Address, ExtendedAddress, FrameVersion, PanId, Security, ShortAddress};
     use bytes::BytesMut;
 
     #[test]

--- a/src/mac/frame/mod.rs
+++ b/src/mac/frame/mod.rs
@@ -11,9 +11,6 @@
 // - change &[u8] => bytes::Buf
 // - remove one variant enums
 
-use core::mem::size_of_val;
-
-use byteorder::{ByteOrder, LittleEndian};
 use bytes::{Buf, BufMut};
 use hash32_derive::Hash32;
 

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -1,21 +1,10 @@
 //! Partial implementation of the IEEE 802.15.4 MAC layer
 
-pub mod frame;
-pub mod command;
 pub mod beacon;
+pub mod command;
+pub mod frame;
 
 pub use frame::{
-    Address,
-    AddressMode,
-    DecodeError,
-    ExtendedAddress,
-    Frame,
-    FrameContent,
-    FrameType,
-    FrameVersion,
-    Header,
-    PanId,
-    Security,
-    ShortAddress,
-    WriteFooter,
+    Address, AddressMode, DecodeError, ExtendedAddress, Frame, FrameContent, FrameType,
+    FrameVersion, Header, PanId, Security, ShortAddress, WriteFooter,
 };

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -5,6 +5,8 @@ pub mod command;
 pub mod frame;
 
 pub use frame::{
-    Address, AddressMode, DecodeError, ExtendedAddress, Frame, FrameContent, FrameType,
-    FrameVersion, Header, PanId, Security, ShortAddress, WriteFooter,
+    Address, DecodeError, ExtendedAddress, Frame, FrameContent, Header, PanId, ShortAddress,
+    WriteFooter,
 };
+
+pub use frame::frame_control::{AddressMode, FrameType, FrameVersion};

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -9,4 +9,4 @@ pub use frame::{
     WriteFooter,
 };
 
-pub use frame::frame_control::{AddressMode, FrameType, FrameVersion};
+pub use frame::frame_control::{AddressMode, FrameControl, FrameType, FrameVersion};

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -4,4 +4,8 @@ pub mod beacon;
 pub mod command;
 pub mod frame;
 
-pub use frame::header;
+pub use frame::header::{
+    Address, AddressMode, ExtendedAddress, FrameType, FrameVersion, Header, PanId, Security,
+    ShortAddress,
+};
+pub use frame::{DecodeError, Frame, FrameContent, WriteFooter};

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -4,9 +4,4 @@ pub mod beacon;
 pub mod command;
 pub mod frame;
 
-pub use frame::{
-    Address, DecodeError, ExtendedAddress, Frame, FrameContent, Header, PanId, ShortAddress,
-    WriteFooter,
-};
-
-pub use frame::frame_control::{AddressMode, FrameControl, FrameType, FrameVersion};
+pub use frame::header;


### PR DESCRIPTION
Changes are listed in CHANGELOG.md

I want to make this crate more handy for people that can use allocation but it should be fully compatible with manually allocated buffers (as it was before this PR)

I couldn't done this for `Frame<'p>::encode()` since I couldn't force it to work with `& dyn Buf`. More details are in in [this issue](https://github.com/tokio-rs/bytes/issues/395)

Closes #9 