### PR TITLE
Remove GitHub Sponsors link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: [hannobraun]


### PR DESCRIPTION
I noticed that still repository still links to my GitHub Sponsors
profile. Since I no longer maintain this repository and re-focused my
GitHub Sponsors profile on other things recently, this seems misleading.