### PR TITLE
Fix #49 and `serde` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,12 @@ default-features = false
 version          = "0.3.0"
 default-features = false
 
+[dependencies.serde]
+version          = "1.0"
+default-features = false
+optional         = true
+features         = [ "derive" ]
+
 [dev-dependencies]
 rand = "0.8.3"
 

--- a/src/mac/frame/frame_control.rs
+++ b/src/mac/frame/frame_control.rs
@@ -107,6 +107,7 @@ impl FrameVersion {
 /// ```
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+
 pub enum AddressMode {
     /// PAN identifier and address field are not present
     None = 0b00,

--- a/src/mac/frame/header.rs
+++ b/src/mac/frame/header.rs
@@ -318,6 +318,7 @@ where
 /// let pan_id = PanId(0x0123);
 /// ```
 #[derive(Clone, Copy, Debug, Eq, Hash, Hash32, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PanId(pub u16);
 
@@ -357,6 +358,8 @@ impl TryRead<'_> for PanId {
 /// ```
 #[derive(Clone, Copy, Debug, Eq, Hash, Hash32, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+
 pub struct ShortAddress(pub u16);
 
 impl ShortAddress {
@@ -397,6 +400,8 @@ impl TryRead<'_> for ShortAddress {
 /// ```
 #[derive(Clone, Copy, Debug, Eq, Hash, Hash32, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+
 pub struct ExtendedAddress(pub u64);
 
 impl ExtendedAddress {
@@ -427,6 +432,7 @@ impl TryRead<'_> for ExtendedAddress {
 /// An address that might contain an PAN ID and address
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Address {
     /// Short (16-bit) address and PAN ID (16-bit)
     Short(PanId, ShortAddress),

--- a/src/mac/frame/header.rs
+++ b/src/mac/frame/header.rs
@@ -261,6 +261,12 @@ where
         // Write Sequence Number
         bytes.write(offset, self.seq)?;
 
+        if (self.destination.is_none() || self.source.is_none())
+            && self.pan_id_compress
+        {
+            return Err(EncodeError::DisallowedPanIdCompress)?;
+        }
+
         // Write addresses
         if let Some(destination) = self.destination {
             bytes.write_with(offset, destination, AddressEncoding::Normal)?;


### PR DESCRIPTION
Fix #49 

Add a `serde` feature that adds serialization/deserialization impls for `Address` (and possibly more in the future)