### PR TITLE
Makes security an optinal default feature

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -16,11 +16,13 @@ jobs:
     - name: Clippy
       uses: actions-rs/cargo@v1
       with:
-        command: clippy --all-features
+        command: clippy
+        args: --all-features
     - name: Clippy
       uses: actions-rs/cargo@v1
       with:
-        command: clippy --no-default-features
+        command: clippy
+        args: --no-default-features
   format:
     runs-on: ubuntu-latest
     steps:
@@ -35,11 +37,13 @@ jobs:
     - name: Check Format
       uses: actions-rs/cargo@v1
       with:
-        command: fmt --all -- --check
-    - name: Check Format No security
+        command: fmt
+        args: --all -- --check
+    - name: Check Format
       uses: actions-rs/cargo@v1
       with:
-        command: fmt --no-default-features --all -- --check
+        command: fmt
+        args: --no-default-features --all -- --check
   build-armv6m:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -18,9 +18,9 @@ jobs:
       with:
         command: clippy --all-features
     - name: Clippy no security
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy --no-default-features 
+      run: |
+        set -ex
+        cargo clippy --no-default-features
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
@@ -35,10 +35,10 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: fmt --all -- --check
-    - name: Check Format no security
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt --no-default-features --all -- --check
+    - name: Check no security
+      run: |
+        set -ex
+        cargo fmt --no-default-features --all -- --check
   build-armv6m:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -39,11 +39,6 @@ jobs:
       with:
         command: fmt
         args: --all -- --check
-    - name: Check Format
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --no-default-features --all -- --check
   build-armv6m:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -17,7 +17,12 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-  format:
+          args: --all-features
+    - name: Clippy no security
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+          args: --no-default-features 
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
@@ -33,6 +38,11 @@ jobs:
       with:
         command: fmt
         args: --all -- --check
+    - name: Check Format no security
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --no-default-features --all -- --check
   build-armv6m:
     runs-on: ubuntu-latest
     steps:
@@ -49,6 +59,10 @@ jobs:
       run: |
         set -ex
         cargo build
+    - name: Build no security
+      run: |
+        set -ex
+        cargo build --no-default-features
   test:
     runs-on: ubuntu-latest
     steps:
@@ -64,3 +78,7 @@ jobs:
       run: |
         set -ex
         cargo test
+    - name: Test no security
+      run: |
+        set -ex
+        cargo test --no-default-features

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -16,13 +16,11 @@ jobs:
     - name: Clippy
       uses: actions-rs/cargo@v1
       with:
-        command: clippy
-          args: --all-features
+        command: clippy --all-features
     - name: Clippy no security
       uses: actions-rs/cargo@v1
       with:
-        command: clippy
-          args: --no-default-features 
+        command: clippy --no-default-features 
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
@@ -36,13 +34,11 @@ jobs:
     - name: Check Format
       uses: actions-rs/cargo@v1
       with:
-        command: fmt
-        args: --all -- --check
+        command: fmt --all -- --check
     - name: Check Format no security
       uses: actions-rs/cargo@v1
       with:
-        command: fmt
-        args: --no-default-features --all -- --check
+        command: fmt --no-default-features --all -- --check
   build-armv6m:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -17,10 +17,11 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy --all-features
-    - name: Clippy no security
-      run: |
-        set -ex
-        cargo clippy --no-default-features
+    - name: Clippy
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy --no-default-features
+  format:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
@@ -35,10 +36,10 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: fmt --all -- --check
-    - name: Check no security
-      run: |
-        set -ex
-        cargo fmt --no-default-features --all -- --check
+    - name: Check Format No security
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt --no-default-features --all -- --check
   build-armv6m:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords      = ["WPAN"]
 
 [features]
 default  = ["security"]
-security = ["cipher"]
+security = ["cipher", "ccm"]
 
 [dependencies]
 hash32        = "0.2.1"
@@ -26,10 +26,8 @@ hash32-derive = "0.1"
 byte = "0.2.7"
 defmt = { version = ">=0.2.0,<0.4", optional = true }
 cipher = {version = "0.3.0", default-features = false, optional = true}
+ccm = { version = "0.4.0", default-features = false, optional = true}
 
-[dependencies.ccm]
-version          = "0.4.0"
-default-features = false
 
 [dependencies.serde]
 version          = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,19 +17,18 @@ categories    = ["embedded", "network-programming", "no-std"]
 keywords      = ["WPAN"]
 
 [features]
+default  = ["security"]
+security = ["cipher"]
 
 [dependencies]
 hash32        = "0.2.1"
 hash32-derive = "0.1"
 byte = "0.2.7"
 defmt = { version = ">=0.2.0,<0.4", optional = true }
+cipher = {version = "0.3.0", default-features = false, optional = true}
 
 [dependencies.ccm]
 version          = "0.4.0"
-default-features = false
-
-[dependencies.cipher]
-version          = "0.3.0"
 default-features = false
 
 [dependencies.serde]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,4 +25,6 @@
 
 #[macro_use]
 mod utils;
+#[allow(unused_imports)]
 pub mod mac;
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,4 +27,3 @@
 mod utils;
 #[allow(unused_imports)]
 pub mod mac;
-

--- a/src/mac/beacon.rs
+++ b/src/mac/beacon.rs
@@ -328,7 +328,7 @@ impl TryRead<'_> for GuaranteedTimeSlotInformation {
                     Direction::Receive
                 };
                 slot.set_direction(direction);
-                direction_mask >>= direction_mask;
+                direction_mask >>= 1;
                 *slot_target = slot;
             }
         }

--- a/src/mac/beacon.rs
+++ b/src/mac/beacon.rs
@@ -102,7 +102,7 @@ const ASSOCIATION_PERMIT: u8 = 0b1000_0000;
 impl TryRead<'_> for SuperframeSpecification {
     fn try_read(bytes: &[u8], _ctx: ()) -> byte::Result<(Self, usize)> {
         let offset = &mut 0;
-        check_len(&bytes, 2)?;
+        check_len(bytes, 2)?;
         let byte: u8 = bytes.read(offset)?;
         let beacon_order = BeaconOrder::from(byte & 0x0f);
         let superframe_order = SuperframeOrder::from((byte >> 4) & 0x0f);
@@ -130,8 +130,8 @@ impl TryRead<'_> for SuperframeSpecification {
 impl TryWrite for SuperframeSpecification {
     fn try_write(self, bytes: &mut [u8], _ctx: ()) -> byte::Result<usize> {
         let offset = &mut 0;
-        let bo = u8::from(self.beacon_order.clone());
-        let so = u8::from(self.superframe_order.clone());
+        let bo = u8::from(self.beacon_order);
+        let so = u8::from(self.superframe_order);
         bytes.write(offset, (bo & 0x0f) | (so << 4))?;
         let ble = if self.battery_life_extension {
             BATTERY_LIFE_EXTENSION
@@ -189,10 +189,16 @@ impl GuaranteedTimeSlotDescriptor {
     }
 }
 
+impl Default for GuaranteedTimeSlotDescriptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TryRead<'_> for GuaranteedTimeSlotDescriptor {
     fn try_read(bytes: &[u8], _ctx: ()) -> byte::Result<(Self, usize)> {
         let offset = &mut 0;
-        check_len(&bytes, 3)?;
+        check_len(bytes, 3)?;
         let short_address = bytes.read(offset)?;
         let byte: u8 = bytes.read(offset)?;
         let starting_slot = byte & 0x0f;
@@ -259,6 +265,12 @@ impl GuaranteedTimeSlotInformation {
     }
 }
 
+impl Default for GuaranteedTimeSlotInformation {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TryWrite for GuaranteedTimeSlotInformation {
     fn try_write(self, bytes: &mut [u8], _ctx: ()) -> byte::Result<usize> {
         let offset = &mut 0;
@@ -275,9 +287,9 @@ impl TryWrite for GuaranteedTimeSlotInformation {
                 for n in 0..self.slot_count {
                     let slot = self.slots[n];
                     if slot.direction_transmit() {
-                        direction_mask = direction_mask | dir;
+                        direction_mask |= dir;
                     }
-                    dir = dir << 1;
+                    dir <<= 1;
                 }
                 direction_mask
             };
@@ -307,7 +319,7 @@ impl TryRead<'_> for GuaranteedTimeSlotInformation {
         if slot_count > 0 {
             check_len(&bytes[*offset..], 2 + (3 * slot_count))?;
             let mut direction_mask: u8 = bytes.read(offset)?;
-            for n in 0..slot_count {
+            for slot_target in slots.iter_mut().take(slot_count) {
                 let mut slot: GuaranteedTimeSlotDescriptor =
                     bytes.read(offset)?;
                 let direction = if direction_mask & 0b1 == 0b1 {
@@ -316,8 +328,8 @@ impl TryRead<'_> for GuaranteedTimeSlotInformation {
                     Direction::Receive
                 };
                 slot.set_direction(direction);
-                direction_mask = direction_mask >> 1;
-                slots[n] = slot;
+                direction_mask >>= direction_mask;
+                *slot_target = slot;
             }
         }
         Ok((
@@ -383,6 +395,12 @@ impl PendingAddress {
     }
 }
 
+impl Default for PendingAddress {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TryRead<'_> for PendingAddress {
     fn try_read(bytes: &[u8], _ctx: ()) -> byte::Result<(Self, usize)> {
         let offset = &mut 0;
@@ -393,12 +411,12 @@ impl TryRead<'_> for PendingAddress {
         let el = ((byte & EXTENDED_MASK) >> 4) as usize;
         check_len(&bytes[*offset..], (sl * ss) + (el * es))?;
         let mut short_addresses = [ShortAddress::broadcast(); 7];
-        for n in 0..sl {
-            short_addresses[n] = bytes.read(offset)?;
+        for short_address in short_addresses.iter_mut().take(sl) {
+            *short_address = bytes.read(offset)?;
         }
         let mut extended_addresses = [ExtendedAddress::broadcast(); 7];
-        for n in 0..el {
-            extended_addresses[n] = bytes.read(offset)?;
+        for extended_address in extended_addresses.iter_mut().take(el) {
+            *extended_address = bytes.read(offset)?;
         }
         Ok((
             Self {

--- a/src/mac/command.rs
+++ b/src/mac/command.rs
@@ -80,19 +80,19 @@ impl From<CapabilityInformation> for u8 {
     fn from(ar: CapabilityInformation) -> Self {
         let mut byte = 0u8;
         if ar.full_function_device {
-            byte = byte | CAP_FFD;
+            byte |= CAP_FFD
         }
         if ar.mains_power {
-            byte = byte | CAP_MAINS_POWER;
+            byte |= CAP_MAINS_POWER
         }
         if ar.idle_receive {
-            byte = byte | CAP_IDLE_RECEIVE;
+            byte |= CAP_IDLE_RECEIVE
         }
         if ar.frame_protection {
-            byte = byte | CAP_FRAME_PROTECTION;
+            byte |= CAP_FRAME_PROTECTION
         }
         if ar.allocate_address {
-            byte = byte | CAP_ALLOCATE_ADDRESS;
+            byte |= CAP_ALLOCATE_ADDRESS
         }
         byte
     }
@@ -157,7 +157,7 @@ impl TryWrite for CoordinatorRealignmentData {
 impl TryRead<'_> for CoordinatorRealignmentData {
     fn try_read(bytes: &[u8], _ctx: ()) -> byte::Result<(Self, usize)> {
         let offset = &mut 0;
-        check_len(&bytes, 7)?;
+        check_len(bytes, 7)?;
         let pan_id = bytes.read(offset)?;
         let coordinator_address = bytes.read(offset)?;
         let channel = bytes.read(offset)?;
@@ -213,10 +213,10 @@ impl From<GuaranteedTimeSlotCharacteristics> for u8 {
     fn from(gtsc: GuaranteedTimeSlotCharacteristics) -> Self {
         let mut byte = gtsc.count & 0x0f;
         if gtsc.receive_only {
-            byte = byte | GTSC_RECEIVE_ONLY;
+            byte |= GTSC_RECEIVE_ONLY
         }
         if gtsc.allocation {
-            byte = byte | GTSC_ALLOCATION;
+            byte |= GTSC_ALLOCATION;
         }
         byte
     }

--- a/src/mac/frame/header.rs
+++ b/src/mac/frame/header.rs
@@ -92,18 +92,13 @@ impl Header {
         // Frame control + sequence number
         let mut len = 3;
 
-        for i in [self.destination, self.source].iter() {
-            match i {
-                Some(addr) => {
-                    // pan ID
-                    len += 2;
-                    // Address length
-                    match addr {
-                        Address::Short(..) => len += 2,
-                        Address::Extended(..) => len += 8,
-                    }
-                }
-                _ => {}
+        for addr in [self.destination, self.source].iter().flatten() {
+            // pan ID
+            len += 2;
+            // Address length
+            match addr {
+                Address::Short(..) => len += 2,
+                Address::Extended(..) => len += 8,
             }
         }
         len
@@ -119,7 +114,7 @@ impl TryRead<'_> for Header {
     fn try_read(bytes: &[u8], _ctx: ()) -> byte::Result<(Self, usize)> {
         let offset = &mut 0;
         // Make sure we have enough buffer for the Frame Control field
-        check_len(&bytes, 3)?;
+        check_len(bytes, 3)?;
 
         /* Decode Frame Control Field */
         let bits: u16 = bytes.read_with(offset, LE)?;

--- a/src/mac/frame/header.rs
+++ b/src/mac/frame/header.rs
@@ -7,13 +7,13 @@
 use super::frame_control::{mask, offset};
 pub use super::frame_control::{AddressMode, FrameType, FrameVersion};
 use super::security::AuxiliarySecurityHeader;
+use super::security::SecurityContext;
 use super::DecodeError;
 use crate::mac::frame::EncodeError;
 #[cfg(not(feature = "security"))]
 use crate::mac::frame::FrameSerDesContext;
 use byte::{check_len, BytesExt, TryRead, TryWrite, LE};
 use hash32_derive::Hash32;
-use super::security::SecurityContext;
 #[cfg(feature = "security")]
 use {
     super::security::KeyDescriptorLookup,

--- a/src/mac/frame/mod.rs
+++ b/src/mac/frame/mod.rs
@@ -28,7 +28,7 @@ pub use header::Header;
 #[cfg(feature = "security")]
 use self::security::{
     default::Unimplemented, DeviceDescriptorLookup, KeyDescriptorLookup,
-    SecurityError, SecurityContext
+    SecurityContext, SecurityError,
 };
 
 /// An IEEE 802.15.4 MAC frame
@@ -561,9 +561,9 @@ impl From<EncodeError> for byte::Error {
 
 #[cfg(test)]
 mod tests {
+    use crate::mac::frame::*;
     #[cfg(feature = "security")]
     use crate::mac::{beacon, command};
-    use crate::mac::frame::*;
     use crate::mac::{
         Address, ExtendedAddress, FrameVersion, PanId, ShortAddress,
     };

--- a/src/mac/frame/mod.rs
+++ b/src/mac/frame/mod.rs
@@ -17,7 +17,7 @@ use crate::mac::command::Command;
 mod frame_control;
 pub mod header;
 pub mod security;
-use byte::{ctx::Bytes, BytesExt, TryRead, TryWrite, LE};
+use byte::{ctx::Bytes, BytesExt, Error, TryRead, TryWrite, LE};
 #[cfg(feature = "security")]
 use ccm::aead::generic_array::typenum::consts::U16;
 #[cfg(feature = "security")]
@@ -25,10 +25,10 @@ use cipher::{BlockCipher, BlockEncrypt, NewBlockCipher};
 use header::FrameType;
 pub use header::Header;
 
+use self::security::{default::Unimplemented, SecurityContext};
 #[cfg(feature = "security")]
 use self::security::{
-    default::Unimplemented, DeviceDescriptorLookup, KeyDescriptorLookup,
-    SecurityContext, SecurityError,
+    DeviceDescriptorLookup, KeyDescriptorLookup, SecurityError,
 };
 
 /// An IEEE 802.15.4 MAC frame
@@ -53,7 +53,6 @@ use self::security::{
 ///     FrameType,
 ///     FooterMode,
 ///     PanId,
-///     FrameSerDesContext,
 /// };
 /// use byte::BytesExt;
 ///
@@ -111,7 +110,7 @@ use self::security::{
 ///   FrameVersion,
 ///   Header,
 ///   PanId,
-///   FrameSerDesContext,
+///   frame::FrameSerDesContext
 /// };
 /// use byte::BytesExt;
 ///
@@ -139,7 +138,7 @@ use self::security::{
 /// let mut bytes = [0u8; 32];
 /// let mut len = 0usize;
 ///
-/// bytes.write_with(&mut len, frame, &mut FrameSerDesContext::no_security(FooterMode::Explicit)).unwrap();
+/// bytes.write_with(&mut len, frame,  &mut FrameSerDesContext::no_security(FooterMode::Explicit)).unwrap();
 ///
 /// let expected_bytes = [
 ///     0x01, 0x98,             // frame control
@@ -210,6 +209,27 @@ where
     }
 }
 
+#[cfg(not(feature = "security"))]
+/// A context that is used for serializing and deserializing frames, which also
+/// stores the frame counter
+pub struct FrameSerDesContext<'a> {
+    /// The footer mode to use when handling frames
+    footer_mode: FooterMode,
+    /// The security context for handling frames (if any)
+    security_ctx: Option<&'a mut SecurityContext>,
+}
+#[cfg(not(feature = "security"))]
+impl FrameSerDesContext<'_> {
+    /// Create a new frame serialization/deserialization context with the specified footer mode,
+    /// that does not facilitate any security functionality
+    pub fn no_security(mode: FooterMode) -> Self {
+        FrameSerDesContext {
+            footer_mode: mode,
+            security_ctx: None,
+        }
+    }
+}
+
 #[cfg(feature = "security")]
 impl FrameSerDesContext<'_, Unimplemented, Unimplemented> {
     /// Create a new frame serialization/deserialization context with the specified footer mode,
@@ -260,6 +280,35 @@ where
                 },
             }
         }
+
+        if !security_enabled {
+            bytes.write(offset, self.payload.as_ref())?;
+        }
+
+        match mode {
+            FooterMode::None => {}
+            // TODO: recalculate the footer after encryption?
+            FooterMode::Explicit => bytes.write(offset, &self.footer[..])?,
+        }
+
+        Ok(*offset)
+    }
+}
+
+#[cfg(not(feature = "security"))]
+impl TryWrite<&mut FrameSerDesContext<'_>> for Frame<'_> {
+    fn try_write(
+        self,
+        bytes: &mut [u8],
+        context: &mut FrameSerDesContext,
+    ) -> byte::Result<usize> {
+        let mode = context.footer_mode;
+        let offset = &mut 0;
+
+        bytes.write_with(offset, self.header, &context.security_ctx)?;
+        bytes.write(offset, self.content)?;
+
+        let security_enabled = false;
 
         if !security_enabled {
             bytes.write(offset, self.payload.as_ref())?;
@@ -562,7 +611,6 @@ impl From<EncodeError> for byte::Error {
 #[cfg(test)]
 mod tests {
     use crate::mac::frame::*;
-    #[cfg(feature = "security")]
     use crate::mac::{beacon, command};
     use crate::mac::{
         Address, ExtendedAddress, FrameVersion, PanId, ShortAddress,
@@ -652,7 +700,7 @@ mod tests {
         assert_eq!(frame.payload.len(), 3);
     }
 
-    #[cfg(feature = "security")]
+    #[cfg(not(feature = "security"))]
     #[test]
     fn encode_ver0_short() {
         let frame = Frame {
@@ -697,7 +745,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "security")]
+    #[cfg(not(feature = "security"))]
     #[test]
     fn encode_ver1_extended() {
         let frame = Frame {
@@ -755,7 +803,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "security")]
+    #[cfg(not(feature = "security"))]
     #[test]
     fn encode_ver0_pan_compress() {
         let frame = Frame {
@@ -800,7 +848,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "security")]
+    #[cfg(not(feature = "security"))]
     #[test]
     fn encode_ver2_none() {
         let frame = Frame {

--- a/src/mac/frame/mod.rs
+++ b/src/mac/frame/mod.rs
@@ -18,14 +18,17 @@ mod frame_control;
 pub mod header;
 pub mod security;
 use byte::{ctx::Bytes, BytesExt, TryRead, TryWrite, LE};
+#[cfg(feature = "security")]
 use ccm::aead::generic_array::typenum::consts::U16;
+#[cfg(feature = "security")]
 use cipher::{BlockCipher, BlockEncrypt, NewBlockCipher};
 use header::FrameType;
 pub use header::Header;
 
+#[cfg(feature = "security")]
 use self::security::{
     default::Unimplemented, DeviceDescriptorLookup, KeyDescriptorLookup,
-    SecurityContext, SecurityError,
+    SecurityError, SecurityContext
 };
 
 /// An IEEE 802.15.4 MAC frame
@@ -176,6 +179,7 @@ pub struct Frame<'p> {
 
 /// A context that is used for serializing and deserializing frames, which also
 /// stores the frame counter
+#[cfg(feature = "security")]
 pub struct FrameSerDesContext<'a, AEADBLKCIPH, KEYDESCLO>
 where
     AEADBLKCIPH: NewBlockCipher + BlockCipher<BlockSize = U16>,
@@ -187,6 +191,7 @@ where
     security_ctx: Option<&'a mut SecurityContext<AEADBLKCIPH, KEYDESCLO>>,
 }
 
+#[cfg(feature = "security")]
 impl<'a, AEADBLKCIPH, KEYDESCLO> FrameSerDesContext<'a, AEADBLKCIPH, KEYDESCLO>
 where
     AEADBLKCIPH: NewBlockCipher + BlockCipher<BlockSize = U16>,
@@ -205,6 +210,7 @@ where
     }
 }
 
+#[cfg(feature = "security")]
 impl FrameSerDesContext<'_, Unimplemented, Unimplemented> {
     /// Create a new frame serialization/deserialization context with the specified footer mode,
     /// that does not facilitate any security functionality
@@ -216,6 +222,7 @@ impl FrameSerDesContext<'_, Unimplemented, Unimplemented> {
     }
 }
 
+#[cfg(feature = "security")]
 impl<AEADBLKCIPH, KEYDESCLO>
     TryWrite<&mut FrameSerDesContext<'_, AEADBLKCIPH, KEYDESCLO>> for Frame<'_>
 where
@@ -277,6 +284,7 @@ impl<'a> Frame<'a> {
     ///
     /// Use [`FrameSerDesContext::no_security`] and/or [`Unimplemented`] if you
     /// do not want to use any security, or simply [`Frame::try_read`]
+    #[cfg(feature = "security")]
     pub fn try_read_and_unsecure<AEADBLKCIPH, KEYDESCLO, DEVDESCLO>(
         buf: &'a mut [u8],
         ctx: &mut FrameSerDesContext<'_, AEADBLKCIPH, KEYDESCLO>,
@@ -553,8 +561,8 @@ impl From<EncodeError> for byte::Error {
 
 #[cfg(test)]
 mod tests {
-    use crate::mac::beacon;
-    use crate::mac::command;
+    #[cfg(feature = "security")]
+    use crate::mac::{beacon, command};
     use crate::mac::frame::*;
     use crate::mac::{
         Address, ExtendedAddress, FrameVersion, PanId, ShortAddress,
@@ -644,6 +652,7 @@ mod tests {
         assert_eq!(frame.payload.len(), 3);
     }
 
+    #[cfg(feature = "security")]
     #[test]
     fn encode_ver0_short() {
         let frame = Frame {
@@ -688,6 +697,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "security")]
     #[test]
     fn encode_ver1_extended() {
         let frame = Frame {
@@ -745,6 +755,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "security")]
     #[test]
     fn encode_ver0_pan_compress() {
         let frame = Frame {
@@ -789,6 +800,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "security")]
     #[test]
     fn encode_ver2_none() {
         let frame = Frame {
@@ -827,6 +839,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "security")]
     #[test]
     fn empty_addressing_and_panid_compress() {
         let mut frame_data = [0u8; 127];

--- a/src/mac/frame/security/auxiliary_security_header.rs
+++ b/src/mac/frame/security/auxiliary_security_header.rs
@@ -1,9 +1,10 @@
 //! All auxiliary security header structs and functions
 
-use super::{
-    KeyDescriptorLookup, KeyIdentifierMode, SecurityContext, SecurityControl,
-};
+#[cfg(feature = "security")]
+use super::{KeyDescriptorLookup, SecurityContext};
+use super::{KeyIdentifierMode, SecurityControl};
 use byte::{BytesExt, TryRead, TryWrite, LE};
+#[cfg(feature = "security")]
 use cipher::{consts::U16, BlockCipher, NewBlockCipher};
 
 /// A struct describing the Auxiliary Security Header
@@ -115,6 +116,7 @@ impl TryRead<'_> for AuxiliarySecurityHeader {
     }
 }
 
+#[cfg(feature = "security")]
 impl<AEADBLKCIPH, KEYDESCLO> TryWrite<&SecurityContext<AEADBLKCIPH, KEYDESCLO>>
     for AuxiliarySecurityHeader
 where

--- a/src/mac/frame/security/default.rs
+++ b/src/mac/frame/security/default.rs
@@ -6,10 +6,12 @@ use super::{
     DeviceDescriptorLookup, KeyDescriptorLookup,
 };
 use crate::mac::Address;
+#[cfg(feature = "security")]
 use ccm::aead::generic_array::{
     typenum::consts::{U1, U16},
     GenericArray,
 };
+#[cfg(feature="security")]
 use cipher::{
     Block, BlockCipher, BlockCipherKey, BlockDecrypt, BlockEncrypt,
     NewBlockCipher,
@@ -19,6 +21,7 @@ use cipher::{
 /// actually capable of performing any of the operations
 pub struct Unimplemented;
 
+#[cfg(feature = "security")]
 impl KeyDescriptorLookup<U16> for Unimplemented {
     fn lookup_key_descriptor(
         &self,
@@ -30,20 +33,24 @@ impl KeyDescriptorLookup<U16> for Unimplemented {
     }
 }
 
+#[cfg(feature="security")]
 impl BlockCipher for Unimplemented {
     type BlockSize = U16;
 
     type ParBlocks = U1;
 }
 
+#[cfg(feature="security")]
 impl BlockEncrypt for Unimplemented {
     fn encrypt_block(&self, _block: &mut Block<Self>) {}
 }
 
+#[cfg(feature="security")]
 impl BlockDecrypt for Unimplemented {
     fn decrypt_block(&self, _block: &mut Block<Self>) {}
 }
 
+#[cfg(feature="security")]
 impl NewBlockCipher for Unimplemented {
     type KeySize = U16;
 

--- a/src/mac/frame/security/default.rs
+++ b/src/mac/frame/security/default.rs
@@ -8,6 +8,7 @@ use super::{
 use crate::mac::Address;
 #[cfg(feature = "security")]
 use {
+    super::KeyDescriptorLookup,
     ccm::aead::generic_array::{
         typenum::consts::{U1, U16},
         GenericArray,
@@ -16,7 +17,6 @@ use {
         Block, BlockCipher, BlockCipherKey, BlockDecrypt, BlockEncrypt,
         NewBlockCipher,
     },
-    super::KeyDescriptorLookup
 };
 
 /// A struct that fullfills all of the trait bounds for serialization and deserializtion, but is not

--- a/src/mac/frame/security/default.rs
+++ b/src/mac/frame/security/default.rs
@@ -3,18 +3,20 @@
 
 use super::{
     auxiliary_security_header::KeyIdentifier, AddressingMode, DeviceDescriptor,
-    DeviceDescriptorLookup, KeyDescriptorLookup,
+    DeviceDescriptorLookup,
 };
 use crate::mac::Address;
 #[cfg(feature = "security")]
-use ccm::aead::generic_array::{
-    typenum::consts::{U1, U16},
-    GenericArray,
-};
-#[cfg(feature="security")]
-use cipher::{
-    Block, BlockCipher, BlockCipherKey, BlockDecrypt, BlockEncrypt,
-    NewBlockCipher,
+use {
+    ccm::aead::generic_array::{
+        typenum::consts::{U1, U16},
+        GenericArray,
+    },
+    cipher::{
+        Block, BlockCipher, BlockCipherKey, BlockDecrypt, BlockEncrypt,
+        NewBlockCipher,
+    },
+    super::KeyDescriptorLookup
 };
 
 /// A struct that fullfills all of the trait bounds for serialization and deserializtion, but is not
@@ -33,24 +35,24 @@ impl KeyDescriptorLookup<U16> for Unimplemented {
     }
 }
 
-#[cfg(feature="security")]
+#[cfg(feature = "security")]
 impl BlockCipher for Unimplemented {
     type BlockSize = U16;
 
     type ParBlocks = U1;
 }
 
-#[cfg(feature="security")]
+#[cfg(feature = "security")]
 impl BlockEncrypt for Unimplemented {
     fn encrypt_block(&self, _block: &mut Block<Self>) {}
 }
 
-#[cfg(feature="security")]
+#[cfg(feature = "security")]
 impl BlockDecrypt for Unimplemented {
     fn decrypt_block(&self, _block: &mut Block<Self>) {}
 }
 
-#[cfg(feature="security")]
+#[cfg(feature = "security")]
 impl NewBlockCipher for Unimplemented {
     type KeySize = U16;
 

--- a/src/mac/frame/security/mod.rs
+++ b/src/mac/frame/security/mod.rs
@@ -4,8 +4,8 @@
 //!
 //! # Example on how to use frames with security
 //! Note that the example below is _very insecure_, and should not be used in any production setting
-//!
-//! ```rust
+#![cfg_attr(not(feature = "security"), doc = "```ignore")]
+#![cfg_attr(feature = "security", doc = "```rust")]
 //! use ieee802154::mac::{
 //!     frame::security::{
 //!         KeyDescriptorLookup,
@@ -270,6 +270,11 @@ where
     /// The NONCEGEN is phantom data as well
     phantom_data: PhantomData<AEADBLKCIPH>,
 }
+
+#[cfg(not(feature = "security"))]
+/// A blank context for when no security is used, but we still want the same API
+#[derive(Clone, Copy)]
+pub struct SecurityContext {}
 
 #[cfg(feature = "security")]
 impl<AEADBLKCIPH, KEYDESCLO> SecurityContext<AEADBLKCIPH, KEYDESCLO>
@@ -1031,6 +1036,7 @@ mod tests {
         test_security_level!(SecurityLevel::ENCMIC128);
     }
 
+    #[cfg(not(feature = "security"))]
     #[test]
     fn encode_decode_secured_frame() {
         let source_euid = 0x08;

--- a/src/mac/frame/security/mod.rs
+++ b/src/mac/frame/security/mod.rs
@@ -167,6 +167,7 @@ use self::default::Unimplemented;
 use super::{FooterMode, Frame, Header};
 use crate::mac::{Address, FrameType, FrameVersion};
 use byte::BytesExt;
+#[cfg(feature = "security")]
 use ccm::{
     aead::{
         generic_array::{
@@ -207,6 +208,7 @@ pub struct DeviceDescriptor {
     pub exempt: bool,
 }
 
+#[cfg(feature = "security")]
 /// Used to create a KeyDescriptor from a KeyIdentifier and device address
 pub trait KeyDescriptorLookup<N>
 where

--- a/src/mac/frame/security/security_control.rs
+++ b/src/mac/frame/security/security_control.rs
@@ -101,6 +101,7 @@ impl SecurityLevel {
         }
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub(crate) fn to_bits(&self) -> u8 {
         match self {
             SecurityLevel::None => 0b000,
@@ -150,6 +151,7 @@ impl KeyIdentifierMode {
             _ => None,
         }
     }
+    #[allow(clippy::wrong_self_convention)]
     fn to_bits(&self) -> u8 {
         match self {
             KeyIdentifierMode::None => 0b00,

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -9,5 +9,7 @@ pub use frame::header::{
     PanId, ShortAddress,
 };
 pub use frame::{
-    security, DecodeError, FooterMode, Frame, FrameContent, FrameSerDesContext,
+    security, DecodeError, FooterMode, Frame, FrameContent,
 };
+#[cfg(feature="security")]
+pub use crate::mac::frame::FrameSerDesContext;

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -4,12 +4,10 @@ pub mod beacon;
 pub mod command;
 pub mod frame;
 
+#[cfg(feature = "security")]
+pub use crate::mac::frame::FrameSerDesContext;
 pub use frame::header::{
     Address, AddressMode, ExtendedAddress, FrameType, FrameVersion, Header,
     PanId, ShortAddress,
 };
-pub use frame::{
-    security, DecodeError, FooterMode, Frame, FrameContent,
-};
-#[cfg(feature="security")]
-pub use crate::mac::frame::FrameSerDesContext;
+pub use frame::{security, DecodeError, FooterMode, Frame, FrameContent};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -48,19 +48,5 @@ macro_rules! extended_enum {
                 }
             }
         }
-
-        // impl PartialEq<$name> for $ty {
-        //     fn eq(&self, other: &$name) -> bool {
-        //         match *other {
-        //             $( $name::$var => *self == $val, )*
-        //         }
-        //     }
-
-        //     fn ne(&self, other: &$name) -> bool {
-        //         match *other {
-        //             $( $name::$var => *self != $val, )*
-        //         }
-        //     }
-        // }
     );
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -49,18 +49,18 @@ macro_rules! extended_enum {
             }
         }
 
-        impl PartialEq<$name> for $ty {
-            fn eq(&self, other: &$name) -> bool {
-                match *other {
-                    $( $name::$var => *self == $val, )*
-                }
-            }
+        // impl PartialEq<$name> for $ty {
+        //     fn eq(&self, other: &$name) -> bool {
+        //         match *other {
+        //             $( $name::$var => *self == $val, )*
+        //         }
+        //     }
 
-            fn ne(&self, other: &$name) -> bool {
-                match *other {
-                    $( $name::$var => *self != $val, )*
-                }
-            }
-        }
+        //     fn ne(&self, other: &$name) -> bool {
+        //         match *other {
+        //             $( $name::$var => *self != $val, )*
+        //         }
+        //     }
+        // }
     );
 }


### PR DESCRIPTION
I made security an optional feature as most zigbee devices don't use it in the mac layer, only the zigbee layer itself.

This has the goal of making the dependency count lower, which allows for manual review of the dependency code, and also increases the targets of compilation as it removes possibly unsupported targets for the crypto crates.

I also fixed some new clippy errors that were added on newer rust versions and had nothing to do with my code