### PR TITLE
Expose more fields in beacon as pub

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name    = "ieee802154"
-version = "0.6.1"
+version = "0.7.0"
 authors = [
   "Erik Henriksson <erikhenrikssn@gmail.com>",
   "Hanno Braun <hanno@braun-robotics.com>",
   "Ryan Kurte <ryan@kurte.nz>",
 ]
-edition = "2018"
+edition = "2021"
 
 description   = "Partial implementation of the IEEE 802.15.4 standard for low-rate wireless personal area networks"
 documentation = "https://docs.rs/ieee802154"
@@ -17,11 +17,14 @@ categories    = ["embedded", "network-programming", "no-std"]
 keywords      = ["WPAN"]
 
 [features]
+defmt = ["dep:defmt", "heapless/defmt-03"]
+serde = ["dep:serde"]
 
 [dependencies]
 hash32        = "0.2.1"
 hash32-derive = "0.1"
 byte = "0.2.7"
+heapless = "0.8.0"
 defmt = { version = ">=0.2.0,<0.4", optional = true }
 
 [dependencies.ccm]

--- a/src/mac/frame/mod.rs
+++ b/src/mac/frame/mod.rs
@@ -151,7 +151,7 @@ use self::security::{
 ///
 /// [decode]: #method.try_read
 /// [encode]: #method.try_write
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Frame<'p> {
     /// Header
@@ -231,13 +231,13 @@ where
         let offset = &mut 0;
 
         bytes.write_with(offset, self.header, &context.security_ctx)?;
-        bytes.write(offset, self.content)?;
+        bytes.write(offset, self.content.clone())?;
 
         let mut security_enabled = false;
 
         if let Some(ctx) = context.security_ctx.as_mut() {
             let write_secured = security::secure_frame(
-                self,
+                self.clone(),
                 ctx,
                 context.footer_mode,
                 &mut bytes[*offset..],
@@ -394,7 +394,7 @@ impl Default for FooterMode {
 }
 
 /// Content of a frame
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum FrameContent {
     /// Beacon frame content

--- a/src/mac/frame/security/mod.rs
+++ b/src/mac/frame/security/mod.rs
@@ -1046,7 +1046,7 @@ mod tests {
         let mut buf = [0u8; 127];
         let mut sec_ctx = aes_sec_ctx(source_euid, FRAME_CTR);
 
-        match frame.try_write(
+        match frame.clone().try_write(
             &mut buf,
             &mut FrameSerDesContext::no_security(FooterMode::None),
         ) {

--- a/src/mac/frame/security/security_control.rs
+++ b/src/mac/frame/security/security_control.rs
@@ -28,6 +28,16 @@ impl SecurityControl {
             key_id_mode: KeyIdentifierMode::None,
         }
     }
+
+    /// Get the security level
+    pub fn security_level(&self) -> SecurityLevel {
+        self.security_level
+    }
+
+    /// Get the key id mode
+    pub fn key_id_mode(&self) -> KeyIdentifierMode {
+        self.key_id_mode
+    }
 }
 
 impl TryRead<'_> for SecurityControl {


### PR DESCRIPTION
For a project I want to not just parse beacon frames but also send them. So I exposed all needed fields to create them.

Since the lists were represented by a pair of length and array, and I wanted to ensure it was impossible to have inconsistent state, I replaced those by `heapless::Vec`. Let me know if this dependency is ok for you.

This made some parts of the frames no longer `Copy`, but I think that is a good thing, since some structs got quite big to copy. (e.g. `PendingAddress` is 70 bytes)